### PR TITLE
Port TLS fixes to 1.6.x kubo release

### DIFF
--- a/jobs/kube-apiserver/spec
+++ b/jobs/kube-apiserver/spec
@@ -55,6 +55,12 @@ properties:
       interactions)
   service-account-public-key:
     description: Public key used to verify service account tokens
+  tls-cipher-suites:
+    description: Comma-separated list of cipher suites.
+    example: |
+      Allowed value is:
+        'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+    default: TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384
   tls.kubelet-client:
     description: kubelet client cert
   tls.kubernetes.ca:
@@ -82,4 +88,5 @@ provides:
   - admin-password
   - tls.kubernetes.ca
   - k8s-args
+  - tls-cipher-suites
   type: kube-apiserver

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -52,6 +52,7 @@ processes:
   <% if !etcd_servers_property_set %>
   - --etcd-servers=<%= etcd_endpoints %>
   <% end %>
+  <%= "- --tls-cipher-suites=#{link('kube-apiserver').p('tls-cipher-suites')}" %>
   env:
     <% if_p('no_proxy') do |no_proxy| %>
     NO_PROXY: <%= no_proxy %>
@@ -76,3 +77,36 @@ processes:
     AWS_SECRET_ACCESS_KEY: <%= secret_access_key %>
     <% end %>
     <% end %>
+
+<%
+  ######################################################################################################
+  # PLEASE KEEP THIS IN SYNC WITH KUBE-APISERVER, KUBE-CONTROLLER-MANAGER, KUBE-SCHEDULER, AND KUBELET #
+  ######################################################################################################
+  def validateCiphers()
+    valid_ciphers = [
+      'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+    ]
+    givenSuites = link('kube-apiserver').p('tls-cipher-suites')
+    unless valid_ciphers.include?(givenSuites)
+      raise "invalid tls-cipher-suites (#{givenSuites}), please use " + valid_ciphers.join('; ')
+    end
+  end
+
+  def validateK8sArgs()
+    if_p('k8s-args') do
+      if p('k8s-args').key?('tls-cipher-suites')
+        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+      end
+    end
+  end
+
+  def validateAll()
+    validateK8sArgs()
+    validateCiphers()
+  end
+
+  validateAll()
+  ############
+  # END SYNC #
+  ############
+%>

--- a/jobs/kube-apiserver/templates/config/bpm.yml.erb
+++ b/jobs/kube-apiserver/templates/config/bpm.yml.erb
@@ -88,14 +88,14 @@ processes:
     ]
     givenSuites = link('kube-apiserver').p('tls-cipher-suites')
     unless valid_ciphers.include?(givenSuites)
-      raise "invalid tls-cipher-suites (#{givenSuites}), please use " + valid_ciphers.join('; ')
+      raise "Invalid tls-cipher-suites (#{givenSuites}), please remove this configuration."
     end
   end
 
   def validateK8sArgs()
     if_p('k8s-args') do
       if p('k8s-args').key?('tls-cipher-suites')
-        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+        raise "Do not set tls-cipher-suites in k8s-args. 'tls-cipher-suites' is set by default and cannot be changed."
       end
     end
   end

--- a/jobs/kube-controller-manager/spec
+++ b/jobs/kube-controller-manager/spec
@@ -47,3 +47,5 @@ consumes:
 - name: cloud-provider
   type: cloud-provider
   optional: true
+- name: kube-apiserver
+  type: kube-apiserver

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -27,6 +27,7 @@ processes:
   - --cloud-provider=<%= cloud_provider.p('cloud-provider.type') %>
   - --cloud-config=/var/vcap/jobs/kube-controller-manager/config/cloud-provider.ini
   <%- end -%>
+  <%= "- --tls-cipher-suites=#{link('kube-apiserver').p('tls-cipher-suites')}" %>
   hooks:
     pre_start: /var/vcap/jobs/kube-controller-manager/bin/chmod-product-serial
   env:
@@ -53,3 +54,20 @@ processes:
     AWS_SECRET_ACCESS_KEY: <%= secret_access_key %>
     <% end %>
     <% end %>
+<%
+  ######################################################################################################
+  # PLEASE KEEP THIS IN SYNC WITH KUBE-APISERVER, KUBE-CONTROLLER-MANAGER, KUBE-SCHEDULER, AND KUBELET #
+  ######################################################################################################
+  def validateK8sArgs()
+    if_p('k8s-args') do
+      if p('k8s-args').key?('tls-cipher-suites')
+        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+      end
+    end
+  end
+
+  validateK8sArgs()
+  ############
+  # END SYNC #
+  ############
+%>

--- a/jobs/kube-controller-manager/templates/config/bpm.yml.erb
+++ b/jobs/kube-controller-manager/templates/config/bpm.yml.erb
@@ -61,7 +61,7 @@ processes:
   def validateK8sArgs()
     if_p('k8s-args') do
       if p('k8s-args').key?('tls-cipher-suites')
-        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+        raise "Do not set tls-cipher-suites in k8s-args. 'tls-cipher-suites' is set by default and cannot be changed."
       end
     end
   end

--- a/jobs/kube-scheduler/spec
+++ b/jobs/kube-scheduler/spec
@@ -25,3 +25,7 @@ properties:
       k8s-args:
         leader-elect: false
         log-flush-frequency: 30s
+
+consumes:
+- name: kube-apiserver
+  type: kube-apiserver

--- a/jobs/kube-scheduler/templates/config/bpm.yml.erb
+++ b/jobs/kube-scheduler/templates/config/bpm.yml.erb
@@ -24,3 +24,22 @@ processes:
     end
   %>
   - --config=/var/vcap/jobs/kube-scheduler/config/config.yml
+  <%= "- --tls-cipher-suites=#{link('kube-apiserver').p('tls-cipher-suites')}" %>
+
+<%
+  ######################################################################################################
+  # PLEASE KEEP THIS IN SYNC WITH KUBE-APISERVER, KUBE-CONTROLLER-MANAGER, KUBE-SCHEDULER, AND KUBELET #
+  ######################################################################################################
+  def validateK8sArgs()
+    if_p('k8s-args') do
+      if p('k8s-args').key?('tls-cipher-suites')
+        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+      end
+    end
+  end
+
+  validateK8sArgs()
+  ############
+  # END SYNC #
+  ############
+%>

--- a/jobs/kube-scheduler/templates/config/bpm.yml.erb
+++ b/jobs/kube-scheduler/templates/config/bpm.yml.erb
@@ -33,7 +33,7 @@ processes:
   def validateK8sArgs()
     if_p('k8s-args') do
       if p('k8s-args').key?('tls-cipher-suites')
-        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+        raise "Do not set tls-cipher-suites in k8s-args. 'tls-cipher-suites' is set by default and cannot be changed."
       end
     end
   end

--- a/jobs/kubelet/spec
+++ b/jobs/kubelet/spec
@@ -76,6 +76,9 @@ consumes:
 - name: cloud-provider
   optional: true
   type: cloud-provider
+# TODO: it doesn't make sense for kubelet to depend on kube-apiserver, should we extract a common config package / job?
+- name: kube-apiserver
+  type: kube-apiserver
 provides:
 - name: kubernetes-workers
   type: kubernetes-workers

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -136,6 +136,7 @@ start_kubelet() {
     --hostname-override=$(get_hostname_override) \
     --node-labels=<%= labels %> \
     --config="/var/vcap/jobs/kubelet/config/kubeletconfig.yml" \
+    --tls-cipher-suites=<%= link('kube-apiserver').p('tls-cipher-suites') %> \
   1>> $LOG_DIR/kubelet.stdout.log \
   2>> $LOG_DIR/kubelet.stderr.log
 }
@@ -184,3 +185,21 @@ case $1 in
     ;;
 
 esac
+
+<%
+  ######################################################################################################
+  # PLEASE KEEP THIS IN SYNC WITH KUBE-APISERVER, KUBE-CONTROLLER-MANAGER, KUBE-SCHEDULER, AND KUBELET #
+  ######################################################################################################
+  def validateK8sArgs()
+    if_p('k8s-args') do
+      if p('k8s-args').key?('tls-cipher-suites')
+        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+      end
+    end
+  end
+
+  validateK8sArgs()
+  ############
+  # END SYNC #
+  ############
+%>

--- a/jobs/kubelet/templates/bin/kubelet_ctl.erb
+++ b/jobs/kubelet/templates/bin/kubelet_ctl.erb
@@ -193,7 +193,7 @@ esac
   def validateK8sArgs()
     if_p('k8s-args') do
       if p('k8s-args').key?('tls-cipher-suites')
-        raise 'do not set tls-cipher-suites in k8s-args. It is set in kube-apiserver and cannot be changed.'
+        raise "Do not set tls-cipher-suites in k8s-args. 'tls-cipher-suites' is set by default and cannot be changed."
       end
     end
   end

--- a/spec/kube_apiserver_bpm_yml_spec.rb
+++ b/spec/kube_apiserver_bpm_yml_spec.rb
@@ -39,7 +39,7 @@ describe 'kube-apiserver' do
       'config/bpm.yml',
       {},
       link_spec)
-    }.to raise_error(/invalid tls-cipher-suites \(INVALID_CIPHER\)/)
+    }.to raise_error(/Invalid tls-cipher-suites \(INVALID_CIPHER\)/)
   end
 
   it 'has no http proxy when no proxy is defined' do

--- a/spec/kube_scheduler_bpm_yml_spec.rb
+++ b/spec/kube_scheduler_bpm_yml_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require 'rspec'
+require 'spec_helper'
+require 'yaml'
+
+describe 'kube_scheduler' do
+  let(:link_spec) do
+    {
+      'kube-apiserver' => {
+        'instances' => [],
+        'properties' => {
+          'tls-cipher-suites' => 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+        }
+      },
+      'etcd' => {
+        'properties' => { },
+        'instances' => [ ]
+      }
+    }
+  end
+
+  it 'has default tls-cipher-suites' do
+    kube_scheduler = compiled_template(
+      'kube-scheduler',
+      'config/bpm.yml',
+      {},
+      link_spec)
+
+    bpm_yml = YAML.safe_load(kube_scheduler)
+    expect(bpm_yml['processes'][0]['args']).to include('--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384')
+  end
+end

--- a/spec/kubelet_ctl_spec.rb
+++ b/spec/kubelet_ctl_spec.rb
@@ -12,9 +12,41 @@ def get_node_labels(rendered_kubelet_ctl)
   labels.split(",")
 end
 
+def call_get_hostname_override(rendered_kubelet_ctl, executable_path)
+  File.open(executable_path, 'w', 0o777) do |f|
+    f.write(rendered_kubelet_ctl)
+  end
+
+  # exercise bash function by changing path for any necessary executables to our mocks in /tmp/mock/*
+  cmd = format('PATH=%<dirname>s:%<env_path>s /bin/bash -c "source %<exe>s && get_hostname_override"',
+               dirname: File.dirname(executable_path), env_path: ENV['PATH'], exe: executable_path)
+
+  # capturing stderr (ignored) prevents expected warnings from showing up in test console
+  result, = Open3.capture3(cmd)
+  result
+end
+
 describe 'kubelet_ctl' do
+  let(:link_spec) do {
+    'kube-apiserver' => {
+      'instances' => [],
+      'properties' => {
+        'tls-cipher-suites' => 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+      }
+    },
+    'etcd' => {
+      'properties' => { },
+      'instances' => [ ]
+    }
+  }
+  end
+
   let(:rendered_template) do
-    compiled_template('kubelet', 'bin/kubelet_ctl', {}, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+    compiled_template('kubelet', 'bin/kubelet_ctl', {}, link_spec, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+  end
+
+  it 'includes default tls-cipher-suites' do
+    expect(rendered_template).to include('--tls-cipher-suites=TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384')
   end
 
   it 'labels the kubelet with its own az' do
@@ -35,7 +67,7 @@ describe 'kubelet_ctl' do
         'node-labels' => 'foo=bar,k8s.node=custom'
       }
     }
-    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, link_spec, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
     labels = get_node_labels(rendered_kubelet_ctl)
 
     expect(labels).to include('bosh.zone=z1')
@@ -50,7 +82,7 @@ describe 'kubelet_ctl' do
       'k8s-args' => {
       }
     }
-    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, {}, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
+    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, link_spec, {}, 'z1', 'fake-bosh-ip', 'fake-bosh-id')
     labels = get_node_labels(rendered_kubelet_ctl)
 
     expect(labels).to include('bosh.zone=z1')
@@ -62,7 +94,8 @@ describe 'kubelet_ctl' do
     rendered_kubelet_ctl = compiled_template(
       'kubelet',
       'bin/kubelet_ctl',
-      {}
+      {},
+      link_spec
     )
 
     expect(rendered_kubelet_ctl).not_to include('export http_proxy')
@@ -74,7 +107,8 @@ describe 'kubelet_ctl' do
     rendered_kubelet_ctl = compiled_template(
       'kubelet',
       'bin/kubelet_ctl',
-      'http_proxy' => 'proxy.example.com:8090'
+      { 'http_proxy' => 'proxy.example.com:8090' },
+      link_spec
     )
 
     expect(rendered_kubelet_ctl).to include('export http_proxy=proxy.example.com:8090')
@@ -84,7 +118,8 @@ describe 'kubelet_ctl' do
     rendered_kubelet_ctl = compiled_template(
       'kubelet',
       'bin/kubelet_ctl',
-      'https_proxy' => 'proxy.example.com:8100'
+      { 'https_proxy' => 'proxy.example.com:8100' },
+      link_spec
     )
 
     expect(rendered_kubelet_ctl).to include('export https_proxy=proxy.example.com:8100')
@@ -94,7 +129,8 @@ describe 'kubelet_ctl' do
     rendered_kubelet_ctl = compiled_template(
       'kubelet',
       'bin/kubelet_ctl',
-      'no_proxy' => 'noproxy.example.com,noproxy.example.net'
+      { 'no_proxy' => 'noproxy.example.com,noproxy.example.net' },
+      link_spec
     )
 
     expect(rendered_kubelet_ctl).to include('export no_proxy=noproxy.example.com,noproxy.example.net')
@@ -107,63 +143,89 @@ describe 'kubelet_ctl' do
           'cloud-provider' => 'azure'
       }
 
-      rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, {}, {}, az="Availability Sets")
+      rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, link_spec, {}, az="Availability Sets")
       expect(rendered_kubelet_ctl).to include('cloud_provider="azure"')
       expect(rendered_kubelet_ctl).not_to include('bosh.zone=Availability Sets')
     end
   end
-end
 
-def call_get_hostname_override(rendered_kubelet_ctl, executable_path)
-  File.open(executable_path, 'w', 0o777) do |f|
-    f.write(rendered_kubelet_ctl)
-  end
+  describe 'setting of --hostname-override property' do
+    let(:test_context) do
+      mock_dir = '/tmp/kubelet_mock'
+      FileUtils.remove_dir(mock_dir, true)
+      FileUtils.mkdir(mock_dir)
+      kubelet_ctl_file = mock_dir + '/kubelet_ctl'
 
-  # exercise bash function by changing path for any necessary executables to our mocks in /tmp/mock/*
-  cmd = format('PATH=%<dirname>s:%<env_path>s /bin/bash -c "source %<exe>s && get_hostname_override"',
-               dirname: File.dirname(executable_path), env_path: ENV['PATH'], exe: executable_path)
+      { 'mock_dir' => mock_dir, 'kubelet_ctl_file' => kubelet_ctl_file }
+    end
+    after(:each) do
+      FileUtils.remove_dir(test_context['mock_dir'], true)
+    end
 
-  # capturing stderr (ignored) prevents expected warnings from showing up in test console
-  result, = Open3.capture3(cmd)
-  result
-end
+    describe 'when cloud-provider is NOT gce' do
+      it 'sets hostname_override to IP address of container IP' do
+        expected_spec_ip = '1111'
+        rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', { 'cloud-provider' => 'nonsense' }, link_spec, {}, 'az1', expected_spec_ip)
+        result = call_get_hostname_override(rendered_kubelet_ctl, test_context['kubelet_ctl_file'])
 
-describe 'kubelet_ctl setting of --hostname-override property' do
-  let(:test_context) do
-    mock_dir = '/tmp/kubelet_mock'
-    FileUtils.remove_dir(mock_dir, true)
-    FileUtils.mkdir(mock_dir)
-    kubelet_ctl_file = mock_dir + '/kubelet_ctl'
+        expect(result).to include(expected_spec_ip)
+      end
+    end
 
-    { 'mock_dir' => mock_dir, 'kubelet_ctl_file' => kubelet_ctl_file }
-  end
-  after(:each) do
-    FileUtils.remove_dir(test_context['mock_dir'], true)
-  end
+    describe 'when cloud-provider is gce' do
+      it 'sets hostname_override to gcp cloud id' do
+        expected_google_hostname = 'i_am_groot'
 
-  describe 'when cloud-provider is NOT gce' do
-    it 'sets hostname_override to IP address of container IP' do
-      expected_spec_ip = '1111'
-      rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', { 'cloud-provider' => 'nonsense' }, {}, {}, 'az1', expected_spec_ip)
-      result = call_get_hostname_override(rendered_kubelet_ctl, test_context['kubelet_ctl_file'])
+        # mock out curl because this code path will try to use it.
+        echo_mock_file = test_context['mock_dir'] + '/curl'
+        File.open(echo_mock_file, 'w', 0o777) do |f|
+          f.write("#!/bin/bash\n")
+          f.write("echo #{expected_google_hostname}")
+        end
 
-      expect(result).to include(expected_spec_ip)
+        manifest_properties = {
+          'cloud-provider' => 'gce'
+        }
+
+        test_link = {
+          'cloud-provider' => {
+            'instances' => [],
+            'properties' => {
+              'cloud-provider' => {
+                'type' => 'gce',
+                'gce' => {
+                  'project-id' => 'f',
+                  'network-name' => 'ff',
+                  'worker-node-tag' => 'fff',
+                  'service_key' => 'ffff'
+                }
+              }
+            }
+          },
+          'kube-apiserver' => {
+            'instances' => [],
+            'properties' => {
+              'tls-cipher-suites' => 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+            }
+          },
+          'etcd' => {
+            'properties' => { },
+            'instances' => [ ]
+          }
+        }
+        rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, test_link)
+        expect(rendered_kubelet_ctl).to include('cloud_provider="gce"')
+
+        result = call_get_hostname_override(rendered_kubelet_ctl, test_context['kubelet_ctl_file'])
+        expect(result).to include(expected_google_hostname)
+      end
     end
   end
 
-  describe 'when cloud-provider is gce' do
-    it 'sets hostname_override to gcp cloud id' do
-      expected_google_hostname = 'i_am_groot'
-
-      # mock out curl because this code path will try to use it.
-      echo_mock_file = test_context['mock_dir'] + '/curl'
-      File.open(echo_mock_file, 'w', 0o777) do |f|
-        f.write("#!/bin/bash\n")
-        f.write("echo #{expected_google_hostname}")
-      end
-
+  context 'when cloud provider is vsphere' do
+    it 'does not set cloud-config' do
       manifest_properties = {
-        'cloud-provider' => 'gce'
+        'cloud-provider' => 'vsphere'
       }
 
       test_link = {
@@ -171,72 +233,52 @@ describe 'kubelet_ctl setting of --hostname-override property' do
           'instances' => [],
           'properties' => {
             'cloud-provider' => {
-              'type' => 'gce',
-              'gce' => {
-                'project-id' => 'f',
-                'network-name' => 'ff',
-                'worker-node-tag' => 'fff',
-                'service_key' => 'ffff'
+              'type' => 'vsphere',
+              'vsphere' => {
+                'user' => 'fake-user',
+                'password' => 'fake-password',
+                'server' => 'fake-server',
+                'port' => 'fake-port',
+                'insecure-flag' => 'fake-insecure-flag',
+                'datacenter' => 'fake-datacenter',
+                'datastore' => 'fake-datastore',
+                'working-dir' => 'fake-working-dir',
+                'vm-uuid' => 'fake-vm-uuid',
+                'scsicontrollertype' => 'fake-scsicontrollertype'
               }
             }
           }
+        },
+        'kube-apiserver' => {
+          'instances' => [],
+          'properties' => {
+            'tls-cipher-suites' => 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+          }
+        },
+        'etcd' => {
+          'properties' => { },
+          'instances' => [ ]
         }
       }
       rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, test_link)
-      expect(rendered_kubelet_ctl).to include('cloud_provider="gce"')
+      expect(rendered_kubelet_ctl).not_to include('--cloud-config')
+      expect(rendered_kubelet_ctl).to include('cloud_provider="vsphere"')
+    end
 
-      result = call_get_hostname_override(rendered_kubelet_ctl, test_context['kubelet_ctl_file'])
-      expect(result).to include(expected_google_hostname)
+    it 'labels the kubelet with its own failure-domain' do
+      manifest_properties = {
+        'cloud-provider' => 'vsphere'
+      }
+      rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, link_spec, {}, 'z1')
+      expect(rendered_kubelet_ctl).to include(',failure-domain.beta.kubernetes.io/zone=z1')
     end
   end
-end
 
-context 'when cloud provider is vsphere' do
-  it 'does not set cloud-config' do
-    manifest_properties = {
-      'cloud-provider' => 'vsphere'
-    }
-
-    test_link = {
-      'cloud-provider' => {
-        'instances' => [],
-        'properties' => {
-          'cloud-provider' => {
-            'type' => 'vsphere',
-            'vsphere' => {
-              'user' => 'fake-user',
-              'password' => 'fake-password',
-              'server' => 'fake-server',
-              'port' => 'fake-port',
-              'insecure-flag' => 'fake-insecure-flag',
-              'datacenter' => 'fake-datacenter',
-              'datastore' => 'fake-datastore',
-              'working-dir' => 'fake-working-dir',
-              'vm-uuid' => 'fake-vm-uuid',
-              'scsicontrollertype' => 'fake-scsicontrollertype'
-            }
-          }
-        }
-      }
-    }
-    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, test_link)
-    expect(rendered_kubelet_ctl).not_to include('--cloud-config')
-    expect(rendered_kubelet_ctl).to include('cloud_provider="vsphere"')
-  end
-
-  it 'labels the kubelet with its own failure-domain' do
-    manifest_properties = {
-      'cloud-provider' => 'vsphere'
-    }
-    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', manifest_properties, {}, {}, 'z1')
-    expect(rendered_kubelet_ctl).to include(',failure-domain.beta.kubernetes.io/zone=z1')
-  end
-end
-
-context 'when there is no cloud-provider link' do
-  it 'does not set cloud options' do
-    rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', {}, {})
-    expect(rendered_kubelet_ctl).not_to include('--cloud-config')
-    expect(rendered_kubelet_ctl).not_to include('--cloud-provider')
+  context 'when there is no cloud-provider link' do
+    it 'does not set cloud options' do
+      rendered_kubelet_ctl = compiled_template('kubelet', 'bin/kubelet_ctl', {}, link_spec)
+      expect(rendered_kubelet_ctl).not_to include('--cloud-config')
+      expect(rendered_kubelet_ctl).not_to include('--cloud-provider')
+    end
   end
 end

--- a/spec/passthrough_flags_spec.rb
+++ b/spec/passthrough_flags_spec.rb
@@ -6,6 +6,34 @@ require 'yaml'
 
 describe 'flag_generation_tests' do
 
+  let(:link_spec) do
+    {
+      'kube-apiserver' => {
+        'address' => 'fake.kube-api-address',
+        'instances' => [],
+        'properties' => {
+          'tls-cipher-suites' => 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256,TLS_ECDHE_RSA_WITH_AES_256_GCM_SHA384'
+        }
+      },
+      'etcd' => {
+        'address' => 'fake-etcd-address',
+        'properties' => { 'etcd' => { 'advertise_urls_dns_suffix' => 'dns-suffix' } },
+        'instances' => [
+          {
+            'name' => 'etcd',
+            'index' => 0,
+            'address' => 'fake-etcd-address-0'
+          },
+          {
+            'name' => 'etcd',
+            'index' => 1,
+            'address' => 'fake-etcd-address-1'
+          }
+        ]
+      }
+    }
+  end
+
   k8s_args = {
     'k8s-args' => {
       'hash': {
@@ -18,6 +46,12 @@ describe 'flag_generation_tests' do
       'string' => "value",
       'flagNil' => nil,
       'colonSuffix' => "value:"
+    }
+  }
+
+  k8s_args_with_tls_cipher_suites = {
+    'k8s-args' => {
+      'tls-cipher-suites' => 'TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256'
     }
   }
 
@@ -47,39 +81,24 @@ describe 'flag_generation_tests' do
       kube_controller_manager = compiled_template(
         'kube-controller-manager',
         'config/bpm.yml',
-        k8s_args)
+        k8s_args,
+        link_spec)
 
       test_bpm(kube_controller_manager)
+    end
+
+    it 'rejects tls-cipher-suites in k8s_args' do
+      expect {
+        compiled_template(
+          'kube-controller-manager',
+          'config/bpm.yml',
+          k8s_args_with_tls_cipher_suites,
+          link_spec)
+      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
     end
   end
 
   context 'kube-apiserver' do
-    let(:link_spec) do
-      {
-        'kube-apiserver' => {
-          'address' => 'fake.kube-api-address',
-          'instances' => [],
-          'properties' => {}
-        },
-        'etcd' => {
-          'address' => 'fake-etcd-address',
-          'properties' => { 'etcd' => { 'advertise_urls_dns_suffix' => 'dns-suffix' } },
-          'instances' => [
-            {
-              'name' => 'etcd',
-              'index' => 0,
-              'address' => 'fake-etcd-address-0'
-            },
-            {
-              'name' => 'etcd',
-              'index' => 1,
-              'address' => 'fake-etcd-address-1'
-            }
-          ]
-        }
-      }
-    end
-
     it 'passes through args correctly' do
       kube_apiserver = compiled_template(
         'kube-apiserver',
@@ -89,6 +108,16 @@ describe 'flag_generation_tests' do
 
       test_bpm(kube_apiserver)
     end
+
+    it 'rejects tls-cipher-suites in k8s_args' do
+      expect {
+        compiled_template(
+          'kube-apiserver',
+          'config/bpm.yml',
+          k8s_args_with_tls_cipher_suites,
+          link_spec)
+      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
+    end
   end
 
   context 'kubelet' do
@@ -96,9 +125,20 @@ describe 'flag_generation_tests' do
       kubelet = compiled_template(
         'kubelet',
         'bin/kubelet_ctl',
-        k8s_args)
+        k8s_args,
+        link_spec)
 
       test_ctl(kubelet)
+    end
+
+    it 'rejects tls-cipher-suites in k8s_args' do
+      expect {
+        compiled_template(
+          'kubelet',
+          'bin/kubelet_ctl',
+          k8s_args_with_tls_cipher_suites,
+          link_spec)
+      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
     end
   end
 
@@ -118,9 +158,20 @@ describe 'flag_generation_tests' do
       kube_scheduler = compiled_template(
         'kube-scheduler',
         'config/bpm.yml',
-        k8s_args)
+        k8s_args,
+        link_spec)
 
       test_bpm(kube_scheduler)
+    end
+
+    it 'rejects tls-cipher-suites in k8s_args' do
+      expect {
+        compiled_template(
+          'kube-scheduler',
+          'config/bpm.yml',
+          k8s_args_with_tls_cipher_suites,
+          link_spec)
+      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
     end
   end
 end

--- a/spec/passthrough_flags_spec.rb
+++ b/spec/passthrough_flags_spec.rb
@@ -94,7 +94,7 @@ describe 'flag_generation_tests' do
           'config/bpm.yml',
           k8s_args_with_tls_cipher_suites,
           link_spec)
-      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
+      }.to raise_error.with_message(/Do not set tls-cipher-suites in k8s-args/)
     end
   end
 
@@ -116,7 +116,7 @@ describe 'flag_generation_tests' do
           'config/bpm.yml',
           k8s_args_with_tls_cipher_suites,
           link_spec)
-      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
+      }.to raise_error.with_message(/Do not set tls-cipher-suites in k8s-args/)
     end
   end
 
@@ -138,7 +138,7 @@ describe 'flag_generation_tests' do
           'bin/kubelet_ctl',
           k8s_args_with_tls_cipher_suites,
           link_spec)
-      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
+      }.to raise_error.with_message(/Do not set tls-cipher-suites in k8s-args/)
     end
   end
 
@@ -171,7 +171,7 @@ describe 'flag_generation_tests' do
           'config/bpm.yml',
           k8s_args_with_tls_cipher_suites,
           link_spec)
-      }.to raise_error.with_message(/do not set tls-cipher-suites in k8s-args/)
+      }.to raise_error.with_message(/Do not set tls-cipher-suites in k8s-args/)
     end
   end
 end


### PR DESCRIPTION
**What this PR does / why we need it**:
<!--
Why is this PR important? What is the user impact?
-->

**How can this PR be verified?**
https://pks.ci.cf-app.com/teams/dev/pipelines/pks-api-deployment-1.6.x_tls

**Is there any change in kubo-deployment?**

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note
Adds updated TLS and cipher suites to 1.6.x kubo-release
```
