### PR TITLE
Bump etcd client version to 3.3.17

### DIFF
--- a/config/blobs.yml
+++ b/config/blobs.yml
@@ -38,18 +38,18 @@ container-images/vmware_metrics-server-amd64:v0.3.3.tgz:
   size: 12059532
   object_id: 876a3f5f-40dd-4f03-614d-bc77aa3b3a8b
   sha: sha256:602e6d08842dd51e099839af097b4e7dc865018e0576b9abb91f6b174ec34380
-container-images/vmware_pause:3.1.tgz:
-  size: 314768
-  object_id: 2224d7c6-0395-49ea-7356-0b04d413e8ae
-  sha: sha256:8b7f7da2677ac899f712ea89cb2f0683f8a42c8cd339512c58df0aa4d162e8cb
 container-images/vmware_nginx-bionic:1.0.0.tgz:
   size: 66797183
   object_id: 370b05ca-2ad8-4f1b-6002-22ea8ce709fc
   sha: sha256:27ed75ab7de88b3b58c5117357eee4baa77e53140b3cba7ed3f678a0bfa253ee
-etcdctl-3.0.7:
-  size: 18427584
-  object_id: 32221476-5c3d-4ec7-5869-44c989cc3077
-  sha: 11f0462cc86bf85332399a2fa584d5bb46d0cb2a
+container-images/vmware_pause:3.1.tgz:
+  size: 314768
+  object_id: 2224d7c6-0395-49ea-7356-0b04d413e8ae
+  sha: sha256:8b7f7da2677ac899f712ea89cb2f0683f8a42c8cd339512c58df0aa4d162e8cb
+etcdctl-3.3.17:
+  size: 17770784
+  object_id: c018cb11-7692-489f-4d73-83be55c33dac
+  sha: sha256:dd0ac971beefb8bc2b655b78851b08a9a5b717ca87ca20540237c4d17fa385d0
 flannel-v0.11.0-linux-amd64.tar.gz:
   size: 9565743
   object_id: 83064ebe-b45d-4d41-694a-b1e61a781250

--- a/packages/etcdctl/packaging
+++ b/packages/etcdctl/packaging
@@ -1,7 +1,7 @@
 set -e
 
 ETCDCTL_PACKAGE=etcdctl
-ETCDCTL_VERSION="3.0.7"
+ETCDCTL_VERSION="3.3.17"
 
 main() {
   copy_binary

--- a/packages/etcdctl/spec
+++ b/packages/etcdctl/spec
@@ -4,4 +4,4 @@ name: etcdctl
 dependencies:
 
 files:
-- etcdctl-3.0.7
+- etcdctl-3.3.17


### PR DESCRIPTION
Updates etcd client version to 3.3.17

Pipeline: https://pks.ci.cf-app.com/teams/dev/pipelines/pks-api-1.7.x-etcd-client-update

[#170639369]

Co-authored-by: Sam Mirza <smirza@pivotal.io>
Co-authored-by: Todd Sedano <tsedano@pivotal.io>
Co-authored-by: Shimon Walner <swalner@pivotal.io>
