### PR TITLE
Update kube-scheduler job to accept file-arg k8s-pargs

### DIFF
--- a/jobs/kube-scheduler/spec
+++ b/jobs/kube-scheduler/spec
@@ -2,13 +2,16 @@
 name: kube-scheduler
 
 templates:
+  bin/generate-config-files: bin/generate-config-files
   config/bpm.yml.erb: config/bpm.yml
   config/ca.pem.erb: config/ca.pem
+  config/file-arguments.json.erb: config/file-arguments.json
   config/kubeconfig.erb: config/kubeconfig
   config/config.yml: config/config.yml
 
 packages:
 - kubernetes
+- file-generator
 
 properties:
   api-token:
@@ -25,6 +28,11 @@ properties:
       k8s-args:
         leader-elect: false
         log-flush-frequency: 30s
+  file-arguments:
+    description: "Pass-through options for Kubernetes runtime arguments which accept local file paths as inputs. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kube-scheduler/ for reference."
+    example: |
+      file-arguments:
+        azure-container-registry-config: base64 encoded config
 
 consumes:
 - name: kube-apiserver

--- a/jobs/kube-scheduler/templates/bin/generate-config-files
+++ b/jobs/kube-scheduler/templates/bin/generate-config-files
@@ -1,0 +1,9 @@
+#!/bin/bash -exu
+
+chmod +x /var/vcap/packages/file-generator/bin/file_generator
+
+config_file_name=/var/vcap/jobs/kube-scheduler/config/file-arguments.json
+
+if [ -f $config_file_name ]; then
+    /var/vcap/packages/file-generator/bin/file_generator $config_file_name kube-scheduler
+fi

--- a/jobs/kube-scheduler/templates/config/bpm.yml.erb
+++ b/jobs/kube-scheduler/templates/config/bpm.yml.erb
@@ -23,9 +23,20 @@ processes:
       end
     end
   %>
+  <%
+    if_p('file-arguments') do |args|
+      args.each do |flag, content|
+        fileName = "/var/vcap/jobs/kube-scheduler/config/"+flag
+  %>
+  - "<%= "--#{flag}=#{fileName}" %>"
+  <%
+      end
+    end
+  %>
   - --config=/var/vcap/jobs/kube-scheduler/config/config.yml
   <%= "- --tls-cipher-suites=#{link('kube-apiserver').p('tls-cipher-suites')}" %>
-
+  hooks:
+    pre_start: /var/vcap/jobs/kube-scheduler/bin/generate-config-files
 <%
   ############################################################################################################
   # PLEASE KEEP THIS IN SYNC WITH KUBE-APISERVER, KUBE-CONTROLLER-MANAGER, KUBE-SCHEDULER, KUBELET, AND ETCD #

--- a/jobs/kube-scheduler/templates/config/file-arguments.json.erb
+++ b/jobs/kube-scheduler/templates/config/file-arguments.json.erb
@@ -1,0 +1,11 @@
+<%
+  require 'json'
+
+  file_args = {}
+  if_p('file-arguments') do |args|
+    args.each do |flag, content|
+      file_args[flag] = content
+    end
+  end
+%>
+<%= file_args.to_json %>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the kube-scheduler job to support file arguments.

**How can this PR be verified?**

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
