### PR TITLE
Update kube-proxy to accept file-arguments

### DIFF
--- a/jobs/kube-proxy/spec
+++ b/jobs/kube-proxy/spec
@@ -3,14 +3,17 @@ name: kube-proxy
 
 templates:
   bin/kube_proxy_ctl.erb: bin/kube_proxy_ctl
+  bin/pre-start: bin/pre-start
   config/kubeconfig.erb: config/kubeconfig
   config/config.yml.erb: config/config.yml
   config/ca.pem.erb: config/ca.pem
+  config/file-arguments.json.erb: config/file-arguments.json
 
 packages:
 - pid_utils
 - kubernetes
 - conntrack
+- file-generator
 
 properties:
   api-token:
@@ -38,3 +41,8 @@ properties:
           CPUManager: true
           DryRun: false
         cleanup: false
+  file-arguments:
+    description: "Pass-through options for Kubernetes runtime arguments which accept local file paths as inputs. See docs https://kubernetes.io/docs/reference/command-line-tools-reference/kube-proxy/ for reference."
+    example: |
+      file-arguments:
+        azure-container-registry-config: base64 encoded config

--- a/jobs/kube-proxy/templates/bin/kube_proxy_ctl.erb
+++ b/jobs/kube-proxy/templates/bin/kube_proxy_ctl.erb
@@ -66,6 +66,16 @@ start_kubernetes_proxy() {
       end
     end
   -%>
+  <%-
+    if_p('file-arguments') do |args|
+      args.each do |flag, content|
+        fileName = "/var/vcap/jobs/kube-proxy/config/"+flag
+  -%>
+  "<%= "--#{flag}=#{fileName}" %>" \
+  <%-
+      end
+    end
+  -%>
   --config=/var/vcap/jobs/kube-proxy/config/config.yml \
   1>> $LOG_DIR/kube_proxy.stdout.log \
   2>> $LOG_DIR/kube_proxy.stderr.log

--- a/jobs/kube-proxy/templates/bin/pre-start
+++ b/jobs/kube-proxy/templates/bin/pre-start
@@ -1,0 +1,9 @@
+#!/bin/bash -exu
+
+chmod +x /var/vcap/packages/file-generator/bin/file_generator
+
+config_file_name=/var/vcap/jobs/kube-proxy/config/file-arguments.json
+
+if [ -f $config_file_name ]; then
+    /var/vcap/packages/file-generator/bin/file_generator $config_file_name kube-proxy
+fi

--- a/jobs/kube-proxy/templates/config/file-arguments.json.erb
+++ b/jobs/kube-proxy/templates/config/file-arguments.json.erb
@@ -1,0 +1,11 @@
+<%
+  require 'json'
+
+  file_args = {}
+  if_p('file-arguments') do |args|
+    args.each do |flag, content|
+      file_args[flag] = content
+    end
+  end
+%>
+<%= file_args.to_json %>


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR updates the kube-proxy job to support file arguments

**How can this PR be verified?**

**Is there any change in kubo-deployment?**
No

**Is there any change in kubo-ci?**
No

**Does this affect upgrade, or is there any migration required?**
No

**Which issue(s) this PR fixes:**

**Release note**:
<!--
Write your release note:
1. Enter your extended release note in the below block. If the PR requires
   additional action from users switching to the new release, include the
   string "action required".
3. If no release note is required, just write "NONE".
-->
```release-note

```
