### PR TITLE
Adjust the way docker is stopped

### DIFF
--- a/jobs/docker/monit
+++ b/jobs/docker/monit
@@ -1,5 +1,5 @@
 check process docker with pidfile /var/vcap/sys/run/docker/docker.pid
   group vcap
   start program "/var/vcap/packages/bosh-helpers/monit_debugger ctl '/var/vcap/jobs/docker/bin/ctl start'"
-  stop program "/var/vcap/packages/bosh-helpers/monit_debugger ctl '/var/vcap/jobs/docker/bin/ctl stop'" with timeout 60 seconds
+  stop program "/var/vcap/packages/bosh-helpers/monit_debugger ctl '/var/vcap/jobs/docker/bin/ctl stop'" with timeout 180 seconds
   if failed unixsocket /var/vcap/sys/run/docker/docker.sock with timeout 5 seconds for 5 cycles then restart

--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -98,11 +98,11 @@ case $1 in
     echo "Stopping docker containers..."
     containers="$(/var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q)"
     if [[ ! -z $containers ]]; then
-      for container in $containers
-      do
-        echo "Stopping docker container ${container}"
-        /var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock stop ${container}
-      done
+      echo "Stopping all docker containers: ${containers}"
+      # default timeout is 10 seconds, this may take longer than that depending on the number of docker
+      # processes running and the time taken to initiate communication with all of them at once
+      /var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock stop ${containers}
+      echo "Number of remaining containers: $(/var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q | wc -l)"
     fi
 
     # Stop Docker daemon

--- a/jobs/docker/templates/bin/ctl
+++ b/jobs/docker/templates/bin/ctl
@@ -96,14 +96,16 @@ case $1 in
   stop)
     # Stop Docker containers
     echo "Stopping docker containers..."
-    containers="$(/var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q)"
-    if [[ ! -z $containers ]]; then
-      echo "Stopping all docker containers: ${containers}"
-      # default timeout is 10 seconds, this may take longer than that depending on the number of docker
+    # stopping 50 containers at a time
+    containers="$(/var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q | head -n 50)"
+    while [[ ! -z "$containers" ]]; do
+      echo "Stopping docker containers: ${containers}"
+      # default timeout per container is 10 seconds, this may take longer than that depending on the number of docker
       # processes running and the time taken to initiate communication with all of them at once
       /var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock stop ${containers}
       echo "Number of remaining containers: $(/var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q | wc -l)"
-    fi
+      containers="$(/var/vcap/packages/docker/bin/docker --host unix://${DOCKER_PID_DIR}/docker.sock ps -q | head -n 50)"
+    done
 
     # Stop Docker daemon
     echo -n "Stopping docker daemon..."


### PR DESCRIPTION
* increases monit's timeout
* stops all docker containers in parallel

[#169740460]

Authored-by: Daniel Keeney <dkeeney@pivotal.io>

This was tested using the following setup:
**Dockerfile**:
```
FROM ubuntu:latest

CMD echo "sleeping 60" && sleep 60 && echo "sleeping 50" && sleep 50
```
(the second echo and sleep was to make sure that `docker stop` would kill the container entirely not just stop the currently running `sleep 60`)

**build command**:
`docker build -t testimage:latest .`

**run.sh**:
```
for i in {0..100}
do
  docker run testimage:latest &
done
```

**stop.sh**:
```
#!/bin/bash

set -eux

start="$(date)"

containers="$(docker ps -q)"
if [[ ! -z $containers ]]; then
  echo "Stopping docker containers: ${containers}"
  docker stop ${containers}
fi

echo "started on $start and ended on $(date)"
echo "remaining containers: $(docker ps -q | wc -l)"
```

# Testing Methodology
In one window, I ran `run.sh` which started 100 containers which were all sleeping.  In another window, I started `watch "docker ps -q | wc -l"` to see the number of running docker containers.  In a third window, I ran `stop.sh`.

This typically exited in about 20 or 30 seconds.  This indicated that communicating with that many docker processes took more than 10 seconds (the default timeout), but it all ended relatively quickly.  Combined with increasing the monit timeout to 180 seconds, I think this will be ok.